### PR TITLE
Shortest path: bugfix when 3 waypoints are aligned but in opposite directions

### DIFF
--- a/static/task.js
+++ b/static/task.js
@@ -194,8 +194,11 @@ var Task, Turnpoint, Waypoint;
 			for (i = 0; i < 8; i += 1) {
 				for (j = 1; j < points.length - 1; j += 1) {
 					if (points[j].radius > 0) {
+						heading1 = computeHeading(path[j], path[j - 1]);
+						heading2 = computeHeading(path[j], path[j + 1]);
+						heading = Math.abs(heading1 - heading2);
 						crossTrackDistance = computeCrossTrackDistance(path[j - 1], path[j + 1], points[j].center, radius);
-						if (Math.abs(crossTrackDistance) < points[j].radius) {
+						if (heading > 90 && Math.abs(crossTrackDistance) < points[j].radius) {
 							alongTrackDistance = computeAlongTrackDistance(path[j - 1], path[j + 1], points[j].center, radius);
 							heading = computeHeading(path[j - 1], path[j + 1]);
 							path[j] = computeOffset(path[j - 1], alongTrackDistance, heading, radius);


### PR DESCRIPTION
`crossTrackDistance` is the distance between the central point and the line between the points before and after.
When this distance is less than the radius, the waypoint is skipped through.

This is correct, but when the waypoints are aligned and not consequential (let's say Paris -> Moscow -> Berlin instead of Paris -> Berlin -> Moscow) the shortest path has the bug that tries to reach the center point in the trackdistance, instead of keeping the real shortest path.

Checking if the task is "going back" fix this.
![before](https://cloud.githubusercontent.com/assets/152236/9787881/a7d5ee84-57c6-11e5-8a5c-3713245154c4.png)
![after](https://cloud.githubusercontent.com/assets/152236/9787885/aff50cbc-57c6-11e5-9b1e-6c228323e2be.png)
